### PR TITLE
Add async_delivery_queue_resolver for per-mailing queue routing

### DIFF
--- a/app/models/caffeinate/mailing.rb
+++ b/app/models/caffeinate/mailing.rb
@@ -122,16 +122,22 @@ module Caffeinate
     # When delay is provided, uses Sidekiq's perform_in to schedule delivery
     # after the specified number of seconds.
     #
+    # When `Caffeinate.config.async_delivery_queue_resolver` returns a queue name for this mailing
+    # and the delivery class responds to `.set` (Sidekiq/ActiveJob), the job is enqueued on that
+    # queue; otherwise it uses the delivery class's default queue.
+    #
     # @param delay_in_seconds [Integer, nil] seconds to wait before delivering (default: immediate)
     def deliver_later!(delay_in_seconds: nil)
       klass = ::Caffeinate.config.async_delivery_class
+      queue = ::Caffeinate.config.async_delivery_queue_for(self)
+      target = queue && klass.respond_to?(:set) ? klass.set(queue: queue) : klass
 
-      if delay_in_seconds.present? && delay_in_seconds.positive? && klass.respond_to?(:perform_in)
-        klass.perform_in(delay_in_seconds, id)
-      elsif klass.respond_to?(:perform_later)
-        klass.perform_later(id)
-      elsif klass.respond_to?(:perform_async)
-        klass.perform_async(id)
+      if delay_in_seconds.present? && delay_in_seconds.positive? && target.respond_to?(:perform_in)
+        target.perform_in(delay_in_seconds, id)
+      elsif target.respond_to?(:perform_later)
+        target.perform_later(id)
+      elsif target.respond_to?(:perform_async)
+        target.perform_async(id)
       else
         raise NoMethodError, "Neither perform_later, perform_async, or perform_in are defined on #{klass}."
       end

--- a/lib/caffeinate/configuration.rb
+++ b/lib/caffeinate/configuration.rb
@@ -17,6 +17,17 @@ module Caffeinate
     # The background worker class for `async_delivery`.
     attr_accessor :async_delivery_class
 
+    # An optional callable (anything responding to `#call`, e.g. a lambda) used to route an
+    # individual `Caffeinate::Mailing` to a specific background queue when it is delivered
+    # asynchronously. It receives the mailing about to be enqueued and must return the name of
+    # the queue to use, or a blank value (`nil`/`""`) to fall back to `async_delivery_class`'s
+    # default queue. Only applied when the delivery class responds to `.set` (Sidekiq/ActiveJob).
+    #
+    # Default is nil (every mailing uses the delivery class's default queue).
+    #
+    #   config.async_delivery_queue_resolver = ->(mailing) { 'critical' if mailing.mailer_class == 'FooMailer' }
+    attr_accessor :async_delivery_queue_resolver
+
     # If true, uses `deliver_later` instead of `deliver`
     attr_accessor :deliver_later
 
@@ -51,6 +62,7 @@ module Caffeinate
       @default_ended_reason = nil
       @default_unsubscribe_reason = nil
       @enabled_drippers = nil
+      @async_delivery_queue_resolver = nil
     end
 
     def now=(val)
@@ -77,6 +89,16 @@ module Caffeinate
 
     def async_delivery_class
       @async_delivery_class.constantize
+    end
+
+    # Resolves the background queue for a given mailing using `async_delivery_queue_resolver`.
+    # Returns nil when no resolver is configured or the resolver returns a blank value, in which
+    # case the delivery class's default queue is used.
+    def async_delivery_queue_for(mailing)
+      return nil unless @async_delivery_queue_resolver.respond_to?(:call)
+
+      queue = @async_delivery_queue_resolver.call(mailing)
+      queue.presence
     end
   end
 end

--- a/spec/models/caffeinate/mailing_spec.rb
+++ b/spec/models/caffeinate/mailing_spec.rb
@@ -194,6 +194,62 @@ describe ::Caffeinate::Mailing do
         mailing.deliver_later!
       end
     end
+
+    context 'with an async_delivery_queue_resolver' do
+      class FakeQueueableDelivery
+        def self.set(_options); end
+        def self.perform_async(_id); end
+        def self.perform_in(_delay, _id); end
+      end
+
+      before do
+        ::Caffeinate.config.async_delivery_class = 'FakeQueueableDelivery'
+      end
+
+      after do
+        ::Caffeinate.config.async_delivery_class = nil
+        ::Caffeinate.config.async_delivery_queue_resolver = nil
+      end
+
+      let(:mailing) { unsent_mailings.first }
+
+      it 'passes the mailing to the resolver' do
+        received = nil
+        ::Caffeinate.config.async_delivery_queue_resolver = ->(m) { received = m; nil }
+        mailing.deliver_later!
+        expect(received).to eq(mailing)
+      end
+
+      context 'when the resolver returns a queue' do
+        before do
+          ::Caffeinate.config.async_delivery_queue_resolver = ->(_m) { 'critical' }
+        end
+
+        it 'enqueues on the resolved queue' do
+          expect(FakeQueueableDelivery).to receive(:set).with(queue: 'critical').and_return(FakeQueueableDelivery)
+          expect(FakeQueueableDelivery).to receive(:perform_async).with(mailing.id)
+          mailing.deliver_later!
+        end
+
+        it 'honors the resolved queue on the delayed path' do
+          expect(FakeQueueableDelivery).to receive(:set).with(queue: 'critical').and_return(FakeQueueableDelivery)
+          expect(FakeQueueableDelivery).to receive(:perform_in).with(60, mailing.id)
+          mailing.deliver_later!(delay_in_seconds: 60)
+        end
+      end
+
+      context 'when the resolver returns a blank value' do
+        before do
+          ::Caffeinate.config.async_delivery_queue_resolver = ->(_m) { nil }
+        end
+
+        it 'does not set a queue and uses the default' do
+          expect(FakeQueueableDelivery).not_to receive(:set)
+          expect(FakeQueueableDelivery).to receive(:perform_async).with(mailing.id)
+          mailing.deliver_later!
+        end
+      end
+    end
   end
 
   context '#end_if_no_mailings' do


### PR DESCRIPTION
## What

Adds an optional `Caffeinate.config.async_delivery_queue_resolver` — a callable that receives each `Caffeinate::Mailing` about to be delivered asynchronously and returns the name of the background queue it should be enqueued on (or a blank value to fall back to the delivery class's default queue).

`Mailing#deliver_later!` applies the resolved queue via `klass.set(queue:)` when the delivery class responds to `.set` (Sidekiq / ActiveJob), for both the immediate and delayed (`perform_in`) paths.

## Why

Async delivery currently routes every mailing to the delivery class's single default queue. This adds a supported seam to route specific mailings (e.g. time-sensitive campaigns) to a higher-priority queue without subclassing the delivery job or reaching into Sidekiq internals.

## Usage

```ruby
Caffeinate.configure do |config|
  config.async_delivery = true
  config.async_delivery_class = 'CaffeinateEmailJob::DeliverJob'

  # Route one campaign's mailings to a priority queue; everything else stays on the default queue.
  config.async_delivery_queue_resolver = ->(mailing) { 'critical' if mailing.mailer_class == 'EmployeeInviteAction' }
end
```

## Backward compatibility

Fully backward compatible. The resolver defaults to `nil`; when it is unset (or returns a blank value), or when the delivery class doesn't respond to `.set`, delivery is unchanged and uses the default queue.

## Tests

Added specs to `spec/models/caffeinate/mailing_spec.rb` covering: the resolver receiving the mailing, enqueuing on the resolved queue (immediate + delayed paths), and the blank/`nil` fallback. Full suite: **270 examples, 0 failures**.
